### PR TITLE
adding stylus imports to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ yarn add @meforma/vue-toaster
 npm install @meforma/vue-toaster
 ```
 
+stylus-loader is also required
+
+```bash
+# yarn
+yarn add stylus-loader@3 stylus
+
+# npm
+npm install stylus-loader@3 stylus
+```
+
 ## Import
 ```js
 // In you main.js


### PR DESCRIPTION
Not sure if this is just me but when I installed vue-toaster in Vue@3 I got the following error running it

```
Failed to compile with 1 errors                                                                                                                                                                                             2:08:19 PM

Failed to resolve loader: stylus-loader
You may need to install it.
```

Just added installing stylus to the documentation but maybe it could be included in the dependencies. 