### PR TITLE
fix: an issue where Vite requires a specific export method

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.3.0",
   "description": "Vue.js toaster notification",
   "main": "src/index.js",
+  "exports": {
+    ".": {
+      "import": "./src/index.js"
+    }
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
otherwise Vite throws this error:
<img width="676" alt="image" src="https://user-images.githubusercontent.com/3253920/145936742-2c78e7bf-765e-412a-b09b-f5efcdd72882.png">
